### PR TITLE
Added the Site Logo .png img to the Hero Section

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -8,6 +8,8 @@ sections:
         url: /docs
         style: primary
     image: images/FrontDoor of Clinic June 2021.jpg
+    content: |
+      ![](/\_static/app-assets/Asset%204GilmanFP%20Logo+WordMark%20V3.png)
   - section_id: features
     type: section_grid
     col_number: three

--- a/src/sass/imports/_header.scss
+++ b/src/sass/imports/_header.scss
@@ -28,7 +28,7 @@
   margin: 0;
 
   img {
-    max-height: 80px;
+    max-height: 36px;
   }
 }
 


### PR DESCRIPTION
Client wanted the site logo to be a lot larger in the center so trying it out in the Hero Section as a transparency/png on top of the banner (w/active color palette) background of Hero Section. It looks ok and is responsive.

NOTE: I went back to the Site Logo max-width in SCSS and changed it back to original/smaller size in the NAV: 80px down to 36px (this was default width).